### PR TITLE
Enable runtime Hugging Face token

### DIFF
--- a/docs/source/guides/private.md
+++ b/docs/source/guides/private.md
@@ -3,7 +3,7 @@
 
 <Tip>
 
-Due to the possibility of leaking access tokens to users of your website or web application, we only support accessing private/gated models from server-side environments (e.g., Node.js) that have access to the process' environment variables.
+The `env.DANGEROUSLY_AVAILABLE_TO_EVERY_USER_HF_TOKEN` field makes the provided token visible to every user of your application. Only use this when the user is explicitly entering their own token. Do not embed your own token with this field and use it at your own risk.
 
 </Tip>
 
@@ -60,4 +60,14 @@ Alternatively, you can set the environment variable directly in your code:
 process.env.HF_TOKEN = 'hf_...';
 
 // ... rest of your code
+```
+
+In browser environments where environment variables are not available, you can set the token at runtime using the `env` object:
+
+```js
+import { env } from '@huggingface/transformers';
+
+// WARNING: This exposes the token to every user.
+// Only use when the user provides their own token.
+env.DANGEROUSLY_AVAILABLE_TO_EVERY_USER_HF_TOKEN = 'hf_...';
 ```

--- a/src/env.js
+++ b/src/env.js
@@ -124,6 +124,9 @@ const localModelPath = RUNNING_LOCALLY
  * @property {Object} customCache The custom cache to use. Defaults to `null`. Note: this must be an object which
  * implements the `match` and `put` functions of the Web Cache API. For more information, see https://developer.mozilla.org/en-US/docs/Web/API/Cache.
  * If you wish, you may also return a `Promise<string>` from the `match` function if you'd like to use a file path instead of `Promise<Response>`.
+ * @property {string|null} [DANGEROUSLY_AVAILABLE_TO_EVERY_USER_HF_TOKEN=null] Access token used when making requests to the Hugging Face Hub.
+ * This value is visible to every user of your application. Only set it when the user is explicitly providing
+ * their own token (e.g., via an input field). Do not use it for any other purpose and use at your own risk.
  */
 
 /** @type {TransformersEnvironment} */
@@ -155,6 +158,8 @@ export const env = {
     useCustomCache: false,
     customCache: null,
     //////////////////////////////////////////////////////
+
+    DANGEROUSLY_AVAILABLE_TO_EVERY_USER_HF_TOKEN: null,
 }
 
 

--- a/tests/utils/hub-auth.test.js
+++ b/tests/utils/hub-auth.test.js
@@ -1,0 +1,28 @@
+import { env } from "../../src/transformers.js";
+import { getFile } from "../../src/utils/hub.js";
+import { jest } from "@jest/globals";
+
+describe("Hub authorization", () => {
+  it("Attaches Authorization header when env.DANGEROUSLY_AVAILABLE_TO_EVERY_USER_HF_TOKEN is set", async () => {
+    const originalFetch = global.fetch;
+    const mockFetch = jest.fn(() => Promise.resolve(new Response(null)));
+    global.fetch = mockFetch;
+
+    const originalHFToken = process.env.HF_TOKEN;
+    const originalHFAccessToken = process.env.HF_ACCESS_TOKEN;
+    delete process.env.HF_TOKEN;
+    delete process.env.HF_ACCESS_TOKEN;
+
+    env.DANGEROUSLY_AVAILABLE_TO_EVERY_USER_HF_TOKEN = "hf_dummy";
+
+    await getFile("https://huggingface.co/any/model");
+
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers.get("Authorization")).toBe("Bearer hf_dummy");
+
+    env.DANGEROUSLY_AVAILABLE_TO_EVERY_USER_HF_TOKEN = null;
+    global.fetch = originalFetch;
+    if (originalHFToken !== undefined) process.env.HF_TOKEN = originalHFToken; else delete process.env.HF_TOKEN;
+    if (originalHFAccessToken !== undefined) process.env.HF_ACCESS_TOKEN = originalHFAccessToken; else delete process.env.HF_ACCESS_TOKEN;
+  });
+});


### PR DESCRIPTION
## Summary
- rename env variable to `DANGEROUSLY_AVAILABLE_TO_EVERY_USER_HF_TOKEN`
- send authorization headers based on the new variable
- document risks and usage for client-side tokens
- adjust tests for renamed variable

## Testing
- `npm test tests/utils/hub-auth.test.js` *(fails: Cannot find module 'jest/bin/jest.js')*
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*
- `npm install` *(fails: connect ENETUNREACH to github.com)*

------
https://chatgpt.com/codex/tasks/task_e_68a353f117dc83249003ab9c92bf8b31